### PR TITLE
LPS-57320 Update CKEditor ee-3.6.x

### DIFF
--- a/_source/core/htmlparser.js
+++ b/_source/core/htmlparser.js
@@ -18,7 +18,7 @@ CKEDITOR.htmlParser = function()
 {
 	this._ =
 	{
-		htmlPartsRegex : new RegExp( '<(?:(?:\\/([^>]+)>)|(?:!--([\\S|\\s]*?)-->)|(?:([^\\s>]+)\\s*((?:(?:"[^"]*")|(?:\'[^\']*\')|[^"\'>])*)\\/?>))', 'g' )
+		htmlPartsRegex: /<(?:(?:\/([^>]+)>)|(?:!--([\S|\s]*?)-->)|(?:([^\/\s>]+)((?:\s+[\w\-:.]+(?:\s*=\s*?(?:(?:"[^"]*")|(?:'[^']*')|[^\s"'\/>]+))?)*)[\S\s]*?(\/?)>))/g
 	};
 };
 
@@ -187,7 +187,7 @@ CKEDITOR.htmlParser = function()
 					var attribs = {},
 						attribMatch,
 						attribsPart = parts[ 4 ],
-						selfClosing = !!( attribsPart && attribsPart.charAt( attribsPart.length - 1 ) == '/' );
+						selfClosing = !!parts[ 5 ];
 
 					if ( attribsPart )
 					{

--- a/_source/plugins/clipboard/plugin.js
+++ b/_source/plugins/clipboard/plugin.js
@@ -409,6 +409,12 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 					// Intercept the paste before it actually takes place.
 					body.on( !CKEDITOR.env.ie ? 'paste' : 'beforepaste', function( evt )
 						{
+							function repeatParagraphs( repeats ) {
+								// Repeat blocks floor((n+1)/2) times.
+								// Even number of repeats - add <br> at the beginning of last <p>.
+								return CKEDITOR.tools.repeat( '</p><p>', ~~ ( repeats / 2 ) ) + ( repeats % 2 == 1 ? '<br>' : '' );
+							}
+
 							if ( depressBeforeEvent )
 								return;
 

--- a/_source/plugins/selection/plugin.js
+++ b/_source/plugins/selection/plugin.js
@@ -278,7 +278,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 						body = doc.getBody(),
 						html = doc.getDocumentElement();
 
-					if ( isMSSelection )
+					if ( CKEDITOR.env.ie )
 					{
 						// Other browsers don't loose the selection if the
 						// editor document loose the focus. In IE, we don't

--- a/_source/plugins/wysiwygarea/plugin.js
+++ b/_source/plugins/wysiwygarea/plugin.js
@@ -663,32 +663,31 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 							data.dialog && editor.openDialog( data.dialog );
 						});
 
+						// Prevent automatic submission in IE #6336
+						CKEDITOR.env.ie && domDocument.on( 'click', function( evt )
+						{
+							var element = evt.data.getTarget();
+							if ( element.is( 'input' ) )
+							{
+								var type = element.getAttribute( 'type' );
+								if ( type == 'submit' || type == 'reset' )
+									evt.data.preventDefault();
+							}
+						});
+
+						// Fix problem with cursor not appearing in IE when clicking below the body
 						if ( CKEDITOR.env.ie )
 						{
-							// Prevent automatic submission in IE #6336
-							domDocument.on( 'click', function( evt )
-							{
-								var element = evt.data.getTarget();
-								if ( element.is( 'input' ) )
-								{
-									var type = element.getAttribute( 'type' );
-									if ( type == 'submit' || type == 'reset' )
-										evt.data.preventDefault();
-								}
-							});
-
-							// Fix problem with cursor not appearing in IE when clicking below the body
 							domDocument.getDocumentElement().on( 'mousedown', function( evt )
 							{
 								if ( evt.data.getTarget().is( 'html' ) )
 								{
-									// IE needs this timeout.
 									setTimeout( function()
 									{
 										editor.focus();
 
-										var body = domDocument.getBody();										
-										var range = editor.getSelection().getRanges()[ 0 ];
+										var body = domDocument.getBody(),
+											range = editor.getSelection().getRanges()[ 0 ];
 										range.moveToElementEditEnd( body );
 										range.select();
 									} );

--- a/_source/plugins/wysiwygarea/plugin.js
+++ b/_source/plugins/wysiwygarea/plugin.js
@@ -663,17 +663,38 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 							data.dialog && editor.openDialog( data.dialog );
 						});
 
-						// Prevent automatic submission in IE #6336
-						CKEDITOR.env.ie && domDocument.on( 'click', function( evt )
+						if ( CKEDITOR.env.ie )
 						{
-							var element = evt.data.getTarget();
-							if ( element.is( 'input' ) )
+							// Prevent automatic submission in IE #6336
+							domDocument.on( 'click', function( evt )
 							{
-								var type = element.getAttribute( 'type' );
-								if ( type == 'submit' || type == 'reset' )
-									evt.data.preventDefault();
-							}
-						});
+								var element = evt.data.getTarget();
+								if ( element.is( 'input' ) )
+								{
+									var type = element.getAttribute( 'type' );
+									if ( type == 'submit' || type == 'reset' )
+										evt.data.preventDefault();
+								}
+							});
+
+							// Fix problem with cursor not appearing in IE when clicking below the body
+							domDocument.getDocumentElement().on( 'mousedown', function( evt )
+							{
+								if ( evt.data.getTarget().is( 'html' ) )
+								{
+									// IE needs this timeout.
+									setTimeout( function()
+									{
+										editor.focus();
+
+										var body = domDocument.getBody();										
+										var range = editor.getSelection().getRanges()[ 0 ];
+										range.moveToElementEditEnd( body );
+										range.select();
+									} );
+								}
+							} );
+						}
 
 						// Gecko/Webkit need some help when selecting control type elements. (#3448)
 						if ( !( CKEDITOR.env.ie || CKEDITOR.env.opera ) )

--- a/_source/plugins/wysiwygarea/plugin.js
+++ b/_source/plugins/wysiwygarea/plugin.js
@@ -98,7 +98,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 
 		if ( CKEDITOR.env.ie )
 		{
-			var $sel = selection.getNative();
+			var $sel = this.document.$.selection;
 
 			// Delete control selections to avoid IE bugs on pasteHTML.
 			if ( $sel.type == 'Control' )


### PR DESCRIPTION
Needed to backport the logic from CKEditor ee-4.0.x version (94830016614992d3bd886a89c2d176837654a9e1 and eaee4dcbddfcd33043a2629df4b641f88789a50e) to the ee-3.6.x version from the liferay-ckeditor repo in order to update the CKEditor zip for liferay-portal ee-6.1.x. 

This commit moved htmldataprocessor from plugin to the core 9fd067cde1c0e84c60bc94fc85faafa70ec3dac5